### PR TITLE
feat: Add multi-asset screening tools (forex, crypto, ETF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,14 @@ Unlike hedge funds competing on speed and information access, you can compete on
 
 **Built for research-driven investment discovery:**
 
-- 🔍 **Systematic screening** - Find opportunities across stocks, forex, and crypto with advanced filters
+- 🔍 **Multi-asset screening** - Dedicated tools for stocks, forex, crypto, and ETFs with advanced filters
 - 📊 **75+ investment metrics** - Fundamental (valuation, margins, returns), technical (RSI, moving averages), and performance fields with TTM/FQ/FY variants
 - 🎯 **6 proven investment strategies** - Pre-configured screens for quality, value, dividend, momentum, and growth investing
 - 💡 **AI-powered exploration** - Natural language queries through Claude ("Find undervalued companies with strong balance sheets")
 - 💰 **Deep financial analysis** - EV, EV/EBIT, EV/EBITDA, PEG, gross/operating margins, ROIC, ROA, ROE
 - ⚡ **Research-optimized** - Minimal (7 fields) for quick scans vs extended (35 fields) for comprehensive analysis
 - 🏦 **Exchange filtering** - Focus on NASDAQ, NYSE, CBOE, or primary listings only
+- 🌍 **Global coverage** - Screen stocks across multiple markets (America, Europe, Asia) and 9,000+ cryptocurrencies
 
 ## Installation
 
@@ -244,6 +245,44 @@ See **[Preset Strategies Guide](docs/presets.md)** for detailed criteria and usa
 ### `list_presets`
 
 List all available preset strategies.
+
+### `screen_forex`
+
+Screen forex pairs based on technical criteria.
+
+**Parameters:**
+- `filters` - Array of filter conditions (field, operator, value)
+- `sort_by` - Field to sort by (default: `"volume"`)
+- `sort_order` - `"asc"` or `"desc"` (default: `"desc"`)
+- `limit` - Number of results (1-200, default: 20)
+
+**Example fields:** `close`, `volume`, `change`, `RSI`, `SMA50`, `SMA200`, `Volatility.M`
+
+### `screen_crypto`
+
+Screen cryptocurrencies based on technical and market criteria.
+
+**Parameters:**
+- `filters` - Array of filter conditions (field, operator, value)
+- `sort_by` - Field to sort by (default: `"market_cap_basic"`)
+- `sort_order` - `"asc"` or `"desc"` (default: `"desc"`)
+- `limit` - Number of results (1-200, default: 20)
+
+**Example fields:** `close`, `market_cap_basic`, `volume`, `change`, `Perf.1M`, `Perf.3M`, `Perf.Y`
+
+### `screen_etf`
+
+Screen ETFs (Exchange-Traded Funds) based on performance and technical criteria.
+
+**Parameters:**
+- `filters` - Array of filter conditions (field, operator, value)
+- `markets` - Markets to scan (default: `["america"]`)
+- `sort_by` - Field to sort by (default: `"market_cap_basic"`)
+- `sort_order` - `"asc"` or `"desc"` (default: `"desc"`)
+- `limit` - Number of results (1-200, default: 20)
+- `columns` - Optional array of columns to return
+
+**Example fields:** `close`, `volume`, `change`, `Perf.1M`, `Perf.Y`, `RSI`, `beta_1_year`
 
 ## Key Features at a Glance
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,6 +158,166 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           properties: {},
         },
       },
+      {
+        name: "screen_forex",
+        description:
+          "Screen forex pairs based on technical criteria. Returns forex pairs matching the specified filters.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            filters: {
+              type: "array",
+              description: "Array of filter conditions to apply",
+              items: {
+                type: "object",
+                properties: {
+                  field: {
+                    type: "string",
+                    description:
+                      "Field name to filter (e.g., 'close', 'volume', 'RSI', 'change')",
+                  },
+                  operator: {
+                    type: "string",
+                    description:
+                      "Comparison operator: greater, less, greater_or_equal, less_or_equal, equal, in_range, etc.",
+                  },
+                  value: {
+                    description:
+                      "Value to compare against (number, string for field comparison, or array [min, max] for in_range)",
+                  },
+                },
+                required: ["field", "operator", "value"],
+              },
+            },
+            sort_by: {
+              type: "string",
+              description: "Field to sort results by. Default: 'volume'",
+            },
+            sort_order: {
+              type: "string",
+              enum: ["asc", "desc"],
+              description: "Sort order. Default: 'desc'",
+            },
+            limit: {
+              type: "number",
+              description: "Number of results to return (1-200). Default: 20",
+              minimum: 1,
+              maximum: 200,
+            },
+          },
+          required: ["filters"],
+        },
+      },
+      {
+        name: "screen_crypto",
+        description:
+          "Screen cryptocurrencies based on technical and market criteria. Returns cryptocurrencies matching the specified filters.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            filters: {
+              type: "array",
+              description: "Array of filter conditions to apply",
+              items: {
+                type: "object",
+                properties: {
+                  field: {
+                    type: "string",
+                    description:
+                      "Field name to filter (e.g., 'close', 'market_cap_basic', 'volume', 'change')",
+                  },
+                  operator: {
+                    type: "string",
+                    description:
+                      "Comparison operator: greater, less, greater_or_equal, less_or_equal, equal, in_range, etc.",
+                  },
+                  value: {
+                    description:
+                      "Value to compare against (number, string for field comparison, or array [min, max] for in_range)",
+                  },
+                },
+                required: ["field", "operator", "value"],
+              },
+            },
+            sort_by: {
+              type: "string",
+              description: "Field to sort results by. Default: 'market_cap_basic'",
+            },
+            sort_order: {
+              type: "string",
+              enum: ["asc", "desc"],
+              description: "Sort order. Default: 'desc'",
+            },
+            limit: {
+              type: "number",
+              description: "Number of results to return (1-200). Default: 20",
+              minimum: 1,
+              maximum: 200,
+            },
+          },
+          required: ["filters"],
+        },
+      },
+      {
+        name: "screen_etf",
+        description:
+          "Screen ETFs (Exchange-Traded Funds) based on performance and technical criteria. Returns ETFs matching the specified filters.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            filters: {
+              type: "array",
+              description: "Array of filter conditions to apply",
+              items: {
+                type: "object",
+                properties: {
+                  field: {
+                    type: "string",
+                    description:
+                      "Field name to filter (e.g., 'close', 'volume', 'change', 'Perf.1M')",
+                  },
+                  operator: {
+                    type: "string",
+                    description:
+                      "Comparison operator: greater, less, greater_or_equal, less_or_equal, equal, in_range, etc.",
+                  },
+                  value: {
+                    description:
+                      "Value to compare against (number, string for field comparison, or array [min, max] for in_range)",
+                  },
+                },
+                required: ["field", "operator", "value"],
+              },
+            },
+            markets: {
+              type: "array",
+              items: { type: "string" },
+              description: "Markets to scan (e.g., ['america']). Default: ['america']",
+            },
+            sort_by: {
+              type: "string",
+              description: "Field to sort results by. Default: 'market_cap_basic'",
+            },
+            sort_order: {
+              type: "string",
+              enum: ["asc", "desc"],
+              description: "Sort order. Default: 'desc'",
+            },
+            limit: {
+              type: "number",
+              description: "Number of results to return (1-200). Default: 20",
+              minimum: 1,
+              maximum: 200,
+            },
+            columns: {
+              type: "array",
+              items: { type: "string" },
+              description: "Optional: specific columns to include in results. If not provided, uses minimal default columns.",
+            },
+          },
+          required: ["filters"],
+        },
+      },
     ],
   };
 });
@@ -222,6 +382,42 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: "text",
               text: JSON.stringify(presets, null, 2),
+            },
+          ],
+        };
+      }
+
+      case "screen_forex": {
+        const result = await screenTool.screenForex(args as any);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case "screen_crypto": {
+        const result = await screenTool.screenCrypto(args as any);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case "screen_etf": {
+        const result = await screenTool.screenETF(args as any);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(result, null, 2),
             },
           ],
         };


### PR DESCRIPTION
Implement three new MCP tools for screening different asset classes:

- screen_forex: Screen 1,759+ forex pairs with technical indicators
- screen_crypto: Screen 9,247+ cryptocurrencies with market data
- screen_etf: Screen ETFs/funds with automatic type filtering

Features:
- Dedicated screening methods for each asset class
- Proper caching and rate limiting per tool
- Asset-specific default columns and sorting
- Comprehensive test coverage (69 tests passing)

Updates:
- Added tool definitions and handlers to MCP server
- Updated README with tool documentation and examples
- Added 2 new tests for ETF screening validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)