### PR TITLE
feat(mcp): harden tool input and output contracts

### DIFF
--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -1,0 +1,128 @@
+const OBJECT_ROW = {
+  type: "object",
+  additionalProperties: true,
+} as const;
+
+export const FILTER_VALUE_SCHEMA = {
+  oneOf: [
+    { type: "number" },
+    { type: "string" },
+    { type: "boolean" },
+    {
+      type: "array",
+      items: { type: "number" },
+      minItems: 2,
+      maxItems: 2,
+    },
+    {
+      type: "array",
+      items: { type: "string" },
+      minItems: 1,
+    },
+    {
+      type: "array",
+      prefixItems: [{ type: "string" }, { type: "number" }],
+      minItems: 2,
+      maxItems: 2,
+    },
+  ],
+  description:
+    "Value to compare against. Empty and not_empty omit value. above_percent and below_percent use [field, percent]. has and has_none_of use a non-empty string array.",
+} as const;
+
+const STRING_ARRAY = {
+  type: "array",
+  items: { type: "string" },
+} as const;
+
+function collectionSchema(name: string) {
+  return {
+    type: "object",
+    properties: {
+      total_count: { type: "integer" },
+      [name]: { type: "array", items: OBJECT_ROW },
+    },
+    required: ["total_count", name],
+    additionalProperties: true,
+  } as const;
+}
+
+export const OUTPUT_SCHEMAS = {
+  screen_stocks: collectionSchema("stocks"),
+  screen_forex: collectionSchema("pairs"),
+  screen_crypto: collectionSchema("cryptocurrencies"),
+  screen_etf: collectionSchema("etfs"),
+  lookup_symbols: {
+    type: "object",
+    properties: {
+      total_count: { type: "integer" },
+      symbols: { type: "array", items: OBJECT_ROW },
+    },
+    required: ["total_count", "symbols"],
+    additionalProperties: true,
+  },
+  search_symbols: {
+    type: "object",
+    properties: {
+      query: { type: "string" },
+      count: { type: "integer" },
+      symbols: { type: "array", items: OBJECT_ROW },
+    },
+    required: ["query", "count", "symbols"],
+    additionalProperties: true,
+  },
+  get_market_metainfo: {
+    type: "object",
+    properties: {
+      market: { type: "string" },
+      requested_fields: STRING_ARRAY,
+      metainfo: OBJECT_ROW,
+    },
+    required: ["market"],
+    additionalProperties: true,
+  },
+  get_ta_summary: {
+    type: "object",
+    properties: {
+      symbols: { type: "array", items: OBJECT_ROW },
+    },
+    required: ["symbols"],
+    additionalProperties: true,
+  },
+  rank_by_ta: {
+    type: "object",
+    properties: {
+      requested_symbols: { type: "integer" },
+      timeframes: STRING_ARRAY,
+      weights: { type: "object", additionalProperties: { type: "number" } },
+      ranked: { type: "array", items: OBJECT_ROW },
+    },
+    required: ["requested_symbols", "timeframes", "weights", "ranked"],
+    additionalProperties: true,
+  },
+  list_fields: {
+    type: "object",
+    properties: {
+      asset_type: { type: "string" },
+      category: { type: "string" },
+      field_count: { type: "integer" },
+      fields: { type: "array", items: OBJECT_ROW },
+    },
+    required: ["asset_type", "category", "field_count", "fields"],
+    additionalProperties: true,
+  },
+  get_preset: {
+    type: "object",
+    additionalProperties: true,
+  },
+  list_presets: {
+    type: "object",
+    properties: {
+      presets: { type: "array", items: OBJECT_ROW },
+    },
+    required: ["presets"],
+    additionalProperties: true,
+  },
+} as const;
+
+export type PublicToolName = keyof typeof OUTPUT_SCHEMAS;

--- a/src/api/validation.ts
+++ b/src/api/validation.ts
@@ -1,0 +1,435 @@
+import type { MetainfoInput } from "./metainfo.js";
+import type { SearchSymbolsInput } from "./search.js";
+import {
+  VALID_TIMEFRAMES,
+  type RanksByTAInput,
+  type TASummaryInput,
+  type Timeframe,
+} from "./ta.js";
+import type { Filter, FilterOperation, ListFieldsInput, ScreenStocksInput } from "./types.js";
+
+const VALID_ASSET_TYPES = ["stock", "forex", "crypto", "etf"] as const;
+const VALID_FIELD_CATEGORIES = ["fundamental", "technical", "performance"] as const;
+const VALID_SEARCH_ASSET_TYPES = ["stock", "forex", "crypto", "cfd", "futures", "index", "economic"] as const;
+const VALID_OPERATORS = [
+  "greater",
+  "less",
+  "greater_or_equal",
+  "less_or_equal",
+  "equal",
+  "not_equal",
+  "in_range",
+  "not_in_range",
+  "crosses",
+  "crosses_above",
+  "crosses_below",
+  "match",
+  "above_percent",
+  "below_percent",
+  "has",
+  "has_none_of",
+  "empty",
+  "not_empty",
+] as const;
+
+const OPERATOR_MAP: Record<(typeof VALID_OPERATORS)[number], FilterOperation> = {
+  greater: "greater",
+  less: "less",
+  greater_or_equal: "egreater",
+  less_or_equal: "eless",
+  equal: "equal",
+  not_equal: "nequal",
+  in_range: "in_range",
+  not_in_range: "not_in_range",
+  crosses: "crosses",
+  crosses_above: "crosses_above",
+  crosses_below: "crosses_below",
+  match: "match",
+  above_percent: "above%",
+  below_percent: "below%",
+  has: "has",
+  has_none_of: "has_none_of",
+  empty: "empty",
+  not_empty: "nempty",
+};
+
+type PlainObject = Record<string, unknown>;
+type ScreenFilterInput = NonNullable<ScreenStocksInput["filters"]>[number];
+
+function isPlainObject(value: unknown): value is PlainObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asObject(value: unknown, context: string): PlainObject {
+  if (!isPlainObject(value)) throw new Error(`${context} must be an object`);
+  return value;
+}
+
+function assertAllowedKeys(value: PlainObject, allowed: readonly string[], context: string): void {
+  const unknown = Object.keys(value).find((key) => !allowed.includes(key));
+  if (unknown !== undefined) throw new Error(`${context} has unknown argument '${unknown}'`);
+}
+
+function nonEmptyString(value: unknown, context: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${context} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown, context: string): string | undefined {
+  if (value === undefined) return undefined;
+  return nonEmptyString(value, context);
+}
+
+function stringArray(
+  value: unknown,
+  context: string,
+  minLength = 1,
+  maxLength = Number.POSITIVE_INFINITY
+): string[] {
+  if (
+    !Array.isArray(value) ||
+    value.length < minLength ||
+    value.length > maxLength ||
+    value.some((item) => typeof item !== "string" || item.length === 0)
+  ) {
+    const range = Number.isFinite(maxLength)
+      ? `${minLength} to ${maxLength}`
+      : `at least ${minLength}`;
+    throw new Error(`${context} must contain ${range} non-empty strings`);
+  }
+  return value;
+}
+
+function optionalStringArray(value: unknown, context: string): string[] | undefined {
+  if (value === undefined) return undefined;
+  return stringArray(value, context);
+}
+function optionalBoundedInteger(
+  value: unknown,
+  minimum: number,
+  maximum: number,
+  message: string
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isInteger(value) || value < minimum || value > maximum) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function finiteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isNumericRange(value: unknown): value is [number, number] {
+  return Array.isArray(value) && value.length === 2 && value.every(finiteNumber);
+}
+
+function isStringList(value: unknown): value is string[] {
+  return Array.isArray(value) && value.length > 0 && value.every(isNonEmptyString);
+}
+
+function validateFilterValue(value: unknown, operator: string, context: string): void {
+
+  if (operator === "empty" || operator === "not_empty") {
+    if (value !== undefined) throw new Error(`${context} operator ${operator} does not accept a value`);
+    return;
+  }
+  if (
+    operator === "greater" ||
+    operator === "less" ||
+    operator === "greater_or_equal" ||
+    operator === "less_or_equal"
+  ) {
+    if (!(finiteNumber(value) || isNonEmptyString(value))) {
+      throw new Error(`${context} operator ${operator} requires a finite number or field-name string`);
+    }
+    return;
+  }
+  if (operator === "equal") {
+    if (!(isNonEmptyString(value) || finiteNumber(value) || typeof value === "boolean")) {
+      throw new Error(`${context} operator equal requires a non-empty string, finite number, or boolean`);
+    }
+    return;
+  }
+  if (operator === "not_equal") {
+    if (!(isNonEmptyString(value) || finiteNumber(value))) {
+      throw new Error(`${context} operator not_equal requires a non-empty string or finite number`);
+    }
+    return;
+  }
+  if (operator === "in_range") {
+    if (!(isNumericRange(value) || isStringList(value))) {
+      throw new Error(`${context} operator in_range requires two finite numbers or a non-empty string array`);
+    }
+    return;
+  }
+  if (operator === "not_in_range") {
+    if (!isNumericRange(value)) throw new Error(`${context} operator not_in_range requires two finite numbers`);
+    return;
+  }
+  if (
+    operator === "crosses" ||
+    operator === "crosses_above" ||
+    operator === "crosses_below" ||
+    operator === "match"
+  ) {
+    if (!isNonEmptyString(value)) throw new Error(`${context} operator ${operator} requires a non-empty string`);
+    return;
+  }
+  if (operator === "above_percent" || operator === "below_percent") {
+    if (!Array.isArray(value) || value.length !== 2 || !isNonEmptyString(value[0]) || !finiteNumber(value[1])) {
+      throw new Error(`${context} operator ${operator} requires [field, finite percent]`);
+    }
+    return;
+  }
+  if (operator === "has" || operator === "has_none_of") {
+    if (!isStringList(value)) throw new Error(`${context} operator ${operator} requires a non-empty string array`);
+    return;
+  }
+}
+
+function validateFilterInput(value: unknown, index: number): ScreenFilterInput {
+  const context = `Invalid filter at index ${index}`;
+  if (!isPlainObject(value)) {
+    throw new Error(`${context}: expected object with {field, operator, value}`);
+  }
+
+  const field = value.field;
+  const operator = value.operator;
+  const missing: string[] = [];
+  if (field === undefined) missing.push("field: undefined");
+  if (operator === undefined) missing.push("operator: undefined");
+  if (
+    typeof operator === "string" &&
+    operator !== "empty" &&
+    operator !== "not_empty" &&
+    value.value === undefined
+  ) {
+    missing.push("value: undefined");
+  }
+  if (missing.length > 0) {
+    throw new Error(`${context}: missing required properties (${missing.join(", ")})`);
+  }
+  assertAllowedKeys(value, ["field", "operator", "value"], context);
+
+  const fieldName = nonEmptyString(field, `${context} field`);
+  const operatorName = nonEmptyString(operator, `${context} operator`);
+  if (!(VALID_OPERATORS as readonly string[]).includes(operatorName)) {
+    throw new Error(`Unknown operator: ${operatorName}. Valid operators: ${VALID_OPERATORS.join(", ")}`);
+  }
+  validateFilterValue(value.value, operatorName, context);
+  return {
+    field: fieldName,
+    operator: operatorName,
+    ...(value.value === undefined ? {} : { value: value.value as ScreenFilterInput["value"] }),
+  };
+}
+
+export function validateScreenFilterInputs(value: unknown): ScreenFilterInput[] {
+  if (!Array.isArray(value)) throw new Error("filters must be an array");
+  return value.map((filter, index) => validateFilterInput(filter, index));
+}
+
+/** Validate and convert MCP filter objects to TradingView filter objects. */
+export function validateScreenFilters(value: unknown): Filter[] {
+  return validateScreenFilterInputs(value).map((filter) => ({
+    left: filter.field,
+    operation: OPERATOR_MAP[filter.operator as keyof typeof OPERATOR_MAP],
+    ...(filter.value === undefined ? {} : { right: filter.value }),
+  }));
+}
+
+export function validateScreenInput(value: unknown, allowMarkets = true): ScreenStocksInput {
+  const input = asObject(value, "screen input");
+  assertAllowedKeys(input, ["filters", "markets", "sort_by", "sort_order", "limit", "columns"], "screen input");
+  if (!allowMarkets && input.markets !== undefined) {
+    throw new Error("screen input has unknown argument 'markets'");
+  }
+
+  const filters = validateScreenFilterInputs(input.filters === undefined ? [] : input.filters);
+  const markets = allowMarkets ? optionalStringArray(input.markets, "markets") : undefined;
+  const sortBy = optionalString(input.sort_by, "sort_by");
+  const sortOrder = input.sort_order;
+  if (sortOrder !== undefined && sortOrder !== "asc" && sortOrder !== "desc") {
+    throw new Error("sort_order must be 'asc' or 'desc'");
+  }
+  const limit = optionalBoundedInteger(
+    input.limit,
+    1,
+    200,
+    "limit must be an integer from 1 to 200"
+  );
+  const columns = optionalStringArray(input.columns, "columns");
+
+  return {
+    filters,
+    ...(markets === undefined ? {} : { markets }),
+    ...(sortBy === undefined ? {} : { sort_by: sortBy }),
+    ...(sortOrder === undefined ? {} : { sort_order: sortOrder }),
+    ...(limit === undefined ? {} : { limit }),
+    ...(columns === undefined ? {} : { columns }),
+  };
+}
+
+export interface LookupSymbolsInput {
+  symbols: string[];
+  columns?: string[];
+}
+
+export function validateLookupInput(value: unknown): LookupSymbolsInput {
+  const input = asObject(value, "lookup input");
+  assertAllowedKeys(input, ["symbols", "columns"], "lookup input");
+  const symbols = stringArray(input.symbols, "symbols", 1, 100);
+  const columns = optionalStringArray(input.columns, "columns");
+  return {
+    symbols,
+    ...(columns === undefined ? {} : { columns }),
+  };
+}
+
+export function validateSearchInput(value: unknown): SearchSymbolsInput {
+  const input = asObject(value, "search input");
+  assertAllowedKeys(input, ["query", "exchange", "asset_type", "limit", "start"], "search input");
+  const query = nonEmptyString(input.query, "query");
+  const exchange = optionalString(input.exchange, "exchange");
+  const assetType = input.asset_type;
+  if (
+    assetType !== undefined &&
+    (typeof assetType !== "string" || !(VALID_SEARCH_ASSET_TYPES as readonly string[]).includes(assetType))
+  ) {
+    throw new Error(`asset_type must be one of: ${VALID_SEARCH_ASSET_TYPES.join(", ")}`);
+  }
+  const limit = optionalBoundedInteger(
+    input.limit,
+    1,
+    50,
+    "limit must be an integer from 1 to 50"
+  );
+  const start = optionalBoundedInteger(
+    input.start,
+    0,
+    Number.MAX_SAFE_INTEGER,
+    "start must be a non-negative integer"
+  );
+  return {
+    query,
+    ...(exchange === undefined ? {} : { exchange }),
+    ...(assetType === undefined ? {} : { asset_type: assetType as SearchSymbolsInput["asset_type"] }),
+    ...(limit === undefined ? {} : { limit }),
+    ...(start === undefined ? {} : { start }),
+  };
+}
+
+export function validateMetainfoInput(value: unknown): MetainfoInput {
+  const input = asObject(value, "metainfo input");
+  assertAllowedKeys(input, ["market", "fields", "mode"], "metainfo input");
+  const market = nonEmptyString(input.market, "market");
+  const fields = optionalStringArray(input.fields, "fields");
+  const mode = input.mode;
+  if (mode !== undefined && mode !== "summary" && mode !== "raw") {
+    throw new Error("mode must be 'summary' or 'raw'");
+  }
+  return {
+    market,
+    ...(fields === undefined ? {} : { fields }),
+    ...(mode === undefined ? {} : { mode }),
+  };
+}
+
+function validateTimeframes(value: unknown): Timeframe[] | undefined {
+  if (value === undefined) return undefined;
+  const timeframes = stringArray(value, "timeframes").map((timeframe) => timeframe as Timeframe);
+  for (const timeframe of timeframes) {
+    if (!(VALID_TIMEFRAMES as readonly string[]).includes(timeframe)) {
+      throw new Error(`invalid timeframe '${timeframe}'`);
+    }
+  }
+  return timeframes;
+}
+
+function validateSymbols(value: unknown): string[] {
+  return stringArray(value, "symbols", 1, 50);
+}
+
+export function validateTASummaryInput(value: unknown): TASummaryInput {
+  const input = asObject(value, "TA input");
+  assertAllowedKeys(input, ["symbols", "timeframes", "include_components"], "TA input");
+  const symbols = validateSymbols(input.symbols);
+  const timeframes = validateTimeframes(input.timeframes);
+  const includeComponents = input.include_components;
+  if (includeComponents !== undefined && typeof includeComponents !== "boolean") {
+    throw new Error("include_components must be a boolean");
+  }
+  return {
+    symbols,
+    ...(timeframes === undefined ? {} : { timeframes }),
+    ...(includeComponents === undefined ? {} : { include_components: includeComponents }),
+  };
+}
+
+export function validateRankByTAInput(value: unknown): RanksByTAInput {
+  const input = asObject(value, "rank_by_ta input");
+  assertAllowedKeys(input, ["symbols", "timeframes", "weights"], "rank_by_ta input");
+  const symbols = validateSymbols(input.symbols);
+  const timeframes = validateTimeframes(input.timeframes);
+  let weights: Record<string, number> | undefined;
+  if (input.weights !== undefined) {
+    const weightObject = asObject(input.weights, "weights");
+    weights = {};
+    for (const [timeframe, weight] of Object.entries(weightObject)) {
+      if (!finiteNumber(weight) || weight < 0) {
+        throw new Error("weights must contain finite non-negative numbers");
+      }
+      weights[timeframe] = weight;
+    }
+  }
+  return {
+    symbols,
+    ...(timeframes === undefined ? {} : { timeframes }),
+    ...(weights === undefined ? {} : { weights }),
+  };
+}
+
+export function validateListFieldsInput(value: unknown): ListFieldsInput {
+  const input = asObject(value, "list_fields input");
+  assertAllowedKeys(input, ["asset_type", "category"], "list_fields input");
+  const assetType = input.asset_type;
+  if (
+    assetType !== undefined &&
+    (typeof assetType !== "string" || !(VALID_ASSET_TYPES as readonly string[]).includes(assetType))
+  ) {
+    throw new Error(`asset_type must be one of: ${VALID_ASSET_TYPES.join(", ")}`);
+  }
+  const category = input.category;
+  if (
+    category !== undefined &&
+    (typeof category !== "string" || !(VALID_FIELD_CATEGORIES as readonly string[]).includes(category))
+  ) {
+    throw new Error(`category must be one of: ${VALID_FIELD_CATEGORIES.join(", ")}`);
+  }
+  return {
+    ...(assetType === undefined ? {} : { asset_type: assetType as ListFieldsInput["asset_type"] }),
+    ...(category === undefined ? {} : { category: category as ListFieldsInput["category"] }),
+  };
+}
+
+export function validatePresetInput(value: unknown): { preset_name: string } {
+  const input = asObject(value, "preset input");
+  assertAllowedKeys(input, ["preset_name"], "preset input");
+  return { preset_name: nonEmptyString(input.preset_name, "preset_name") };
+}
+
+export function validateEmptyToolInput(value: unknown): Record<string, never> {
+  const input = asObject(value, "tool input");
+  assertAllowedKeys(input, [], "tool input");
+  return {};
+}
+
+export { VALID_TIMEFRAMES, VALID_OPERATORS };

--- a/src/cli/presetFile.ts
+++ b/src/cli/presetFile.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { Preset } from "../resources/presets.js";
-import { validateScreenFilters } from "../tools/screen.js";
+import { validateScreenFilters } from "../api/validation.js";
 
 const MAX_PRESET_BYTES = 1024 * 1024;
 const TOP_LEVEL_KEYS = new Set([
@@ -38,65 +38,6 @@ function assertExactKeys(value: Record<string, unknown>, allowed: Set<string>, c
   if (unknown.length) throw new Error(`${context} has unknown keys: ${unknown.join(", ")}`);
 }
 
-function validateFilterValue(value: unknown, operator: string, context: string) {
-  const isFiniteNumber = (item: unknown): item is number =>
-    typeof item === "number" && Number.isFinite(item);
-  const isNonEmptyString = (item: unknown): item is string =>
-    typeof item === "string" && item.length > 0;
-  const isNumericRange = (item: unknown): item is [number, number] =>
-    Array.isArray(item) && item.length === 2 && item.every(isFiniteNumber);
-  const isStringList = (item: unknown): item is string[] =>
-    Array.isArray(item) && item.length > 0 && item.every(isNonEmptyString);
-
-  if (["empty", "not_empty"].includes(operator)) {
-    if (value !== undefined) throw new Error(`${context} operator ${operator} does not accept a value`);
-    return;
-  }
-  if (["greater", "less", "greater_or_equal", "less_or_equal"].includes(operator)) {
-    if (!(isFiniteNumber(value) || isNonEmptyString(value))) {
-      throw new Error(`${context} operator ${operator} requires a finite number or field-name string`);
-    }
-    return;
-  }
-  if (operator === "equal") {
-    if (!(isNonEmptyString(value) || isFiniteNumber(value) || typeof value === "boolean")) {
-      throw new Error(`${context} operator equal requires a non-empty string, finite number, or boolean`);
-    }
-    return;
-  }
-  if (operator === "not_equal") {
-    if (!(isNonEmptyString(value) || isFiniteNumber(value))) {
-      throw new Error(`${context} operator not_equal requires a non-empty string or finite number`);
-    }
-    return;
-  }
-  if (operator === "in_range") {
-    // TradingView also uses in_range as membership for string fields.
-    if (!(isNumericRange(value) || isStringList(value))) {
-      throw new Error(`${context} operator in_range requires two finite numbers or a non-empty string array`);
-    }
-    return;
-  }
-  if (operator === "not_in_range") {
-    if (!isNumericRange(value)) throw new Error(`${context} operator not_in_range requires two finite numbers`);
-    return;
-  }
-  if (["crosses", "crosses_above", "crosses_below", "match"].includes(operator)) {
-    if (!isNonEmptyString(value)) throw new Error(`${context} operator ${operator} requires a non-empty string`);
-    return;
-  }
-  if (["above_percent", "below_percent"].includes(operator)) {
-    if (!Array.isArray(value) || value.length !== 2 || !isNonEmptyString(value[0]) || !isFiniteNumber(value[1])) {
-      throw new Error(`${context} operator ${operator} requires [field, finite percent]`);
-    }
-    return;
-  }
-  if (["has", "has_none_of"].includes(operator)) {
-    if (!isStringList(value)) throw new Error(`${context} operator ${operator} requires a non-empty string array`);
-    return;
-  }
-  // Unknown operators are rejected by the shared runtime validator.
-}
 
 function stringArray(value: unknown, context: string): string[] | undefined {
   if (value === undefined) return undefined;
@@ -128,9 +69,8 @@ export function validatePresetDocument(document: unknown): Preset {
       assertExactKeys(filter as Record<string, unknown>, FILTER_KEYS, `Preset filter[${index}]`);
       const record = filter as Record<string, unknown>;
       if (typeof record.field !== "string" || !record.field || typeof record.operator !== "string" || !record.operator) throw new Error(`Preset filter[${index}] field and operator must be non-empty strings`);
-      validateFilterValue(record.value, record.operator, `Preset filter[${index}]`);
     }
-    validateScreenFilters(filters as any);
+    validateScreenFilters(filters);
   }
 
   if (value.sort_order !== undefined && value.sort_order !== "asc" && value.sort_order !== "desc") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,18 @@ import { FieldsTool } from "./tools/fields.js";
 import { PresetsTool, PRESETS } from "./resources/presets.js";
 import { Cache } from "./utils/cache.js";
 import { RateLimiter } from "./utils/rateLimit.js";
+import { FILTER_VALUE_SCHEMA, OUTPUT_SCHEMAS } from "./api/schemas.js";
+import {
+  validateEmptyToolInput,
+  validateListFieldsInput,
+  validateLookupInput,
+  validateMetainfoInput,
+  validatePresetInput,
+  validateRankByTAInput,
+  validateScreenInput,
+  validateSearchInput,
+  validateTASummaryInput,
+} from "./api/validation.js";
 import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
@@ -63,6 +75,31 @@ const server = new Server(
     },
   }
 );
+function asStructuredContent(value: unknown): Record<string, unknown> {
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return { data: value };
+}
+
+function createToolResult(
+  displayValue: unknown,
+  structuredValue: unknown = displayValue
+): {
+  content: [{ type: "text"; text: string }];
+  structuredContent: Record<string, unknown>;
+} {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(displayValue, null, 2) ?? "null",
+      },
+    ],
+    structuredContent: asStructuredContent(structuredValue),
+  };
+}
+
 
 // List available tools
 server.setRequestHandler(ListToolsRequestSchema, async () => {
@@ -91,11 +128,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                     description: "Comparison operator",
                     enum: ["greater", "less", "greater_or_equal", "less_or_equal", "equal", "not_equal", "in_range", "not_in_range", "crosses", "crosses_above", "crosses_below", "match", "above_percent", "below_percent", "has", "has_none_of", "empty", "not_empty"],
                   },
-                  value: {
-                    description:
-                      "Value to compare against. Not required for 'empty' and 'not_empty' operators. Use number, string, or [min, max] array for in_range. For above_percent/below_percent, use [field_name, percent_number] e.g. ['SMA200', 10] means 10% above/below SMA200. For has/has_none_of, use an array of strings for set-type fields like typespecs.",
-                  },
+                  value: FILTER_VALUE_SCHEMA,
                 },
+                additionalProperties: false,
                 required: ["field", "operator"],
                 examples: [
                   {"field": "return_on_equity", "operator": "greater", "value": 15},
@@ -135,8 +170,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description: "Optional: specific columns to include in results. If not provided, uses minimal default columns. Presets may define extended column sets.",
             },
           },
+          additionalProperties: false,
           required: [],
         },
+        outputSchema: OUTPUT_SCHEMAS.screen_stocks,
         annotations: {
           readOnlyHint: true,
           idempotentHint: true,
@@ -160,7 +197,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description: "Filter fields by category. If omitted, returns all categories",
             },
           },
+          additionalProperties: false,
         },
+        outputSchema: OUTPUT_SCHEMAS.list_fields,
         annotations: {
           readOnlyHint: true,
           idempotentHint: true,
@@ -179,8 +218,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 "Key of preset to retrieve. See tool description for available keys.",
             },
           },
+          additionalProperties: false,
           required: ["preset_name"],
         },
+        outputSchema: OUTPUT_SCHEMAS.get_preset,
         annotations: {
           readOnlyHint: true,
           idempotentHint: true,
@@ -192,7 +233,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         inputSchema: {
           type: "object",
           properties: {},
+          additionalProperties: false,
         },
+        outputSchema: OUTPUT_SCHEMAS.list_presets,
         annotations: {
           readOnlyHint: true,
           idempotentHint: true,
@@ -221,11 +264,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                     description: "Comparison operator",
                     enum: ["greater", "less", "greater_or_equal", "less_or_equal", "equal", "not_equal", "in_range", "not_in_range", "crosses", "crosses_above", "crosses_below", "match", "above_percent", "below_percent", "has", "has_none_of", "empty", "not_empty"],
                   },
-                  value: {
-                    description:
-                      "Value to compare against. Not required for 'empty' and 'not_empty' operators. Use number, string, or [min, max] array for in_range. For above_percent/below_percent, use [field_name, percent_number] e.g. ['SMA200', 10].",
-                  },
+                  value: FILTER_VALUE_SCHEMA,
                 },
+                additionalProperties: false,
                 required: ["field", "operator"],
                 examples: [
                   {"field": "RSI", "operator": "in_range", "value": [40, 60]},
@@ -258,8 +299,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description: "Optional: specific columns to include in results. If not provided, uses default columns.",
             },
           },
+          additionalProperties: false,
           required: [],
         },
+        outputSchema: OUTPUT_SCHEMAS.screen_forex,
         annotations: {
           readOnlyHint: true,
           idempotentHint: true,
@@ -288,11 +331,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                     description: "Comparison operator",
                     enum: ["greater", "less", "greater_or_equal", "less_or_equal", "equal", "not_equal", "in_range", "not_in_range", "crosses", "crosses_above", "crosses_below", "match", "above_percent", "below_percent", "has", "has_none_of", "empty", "not_empty"],
                   },
-                  value: {
-                    description:
-                      "Value to compare against. Not required for 'empty' and 'not_empty' operators. Use number, string, or [min, max] array for in_range. For above_percent/below_percent, use [field_name, percent_number] e.g. ['SMA200', 10].",
-                  },
+                  value: FILTER_VALUE_SCHEMA,
                 },
+                additionalProperties: false,
                 required: ["field", "operator"],
                 examples: [
                   {"field": "RSI", "operator": "in_range", "value": [40, 70]},
@@ -325,8 +366,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description: "Optional: specific columns to include in results. If not provided, uses default columns.",
             },
           },
+          additionalProperties: false,
           required: [],
         },
+        outputSchema: OUTPUT_SCHEMAS.screen_crypto,
         annotations: {
           readOnlyHint: true,
           idempotentHint: true,
@@ -355,11 +398,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                     description: "Comparison operator",
                     enum: ["greater", "less", "greater_or_equal", "less_or_equal", "equal", "not_equal", "in_range", "not_in_range", "crosses", "crosses_above", "crosses_below", "match", "above_percent", "below_percent", "has", "has_none_of", "empty", "not_empty"],
                   },
-                  value: {
-                    description:
-                      "Value to compare against. Not required for 'empty' and 'not_empty' operators. Use number, string, or [min, max] array for in_range. For above_percent/below_percent, use [field_name, percent_number] e.g. ['SMA200', 10].",
-                  },
+                  value: FILTER_VALUE_SCHEMA,
                 },
+                additionalProperties: false,
                 required: ["field", "operator"],
                 examples: [
                   {"field": "return_on_equity", "operator": "greater", "value": 15},
@@ -397,8 +438,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description: "Optional: specific columns to include in results. If not provided, uses minimal default columns.",
             },
           },
+          additionalProperties: false,
           required: [],
         },
+        outputSchema: OUTPUT_SCHEMAS.screen_etf,
         annotations: {
           readOnlyHint: true,
           idempotentHint: true,
@@ -422,8 +465,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description: "Optional: specific columns to include. Default: name, close, change, volume, market_cap_basic, all_time_high, all_time_low, price_52_week_high, price_52_week_low.",
             },
           },
+          additionalProperties: false,
           required: ["symbols"],
         },
+        outputSchema: OUTPUT_SCHEMAS.lookup_symbols,
         annotations: {
           readOnlyHint: true,
           idempotentHint: true,
@@ -460,8 +505,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description: "Offset for pagination (default: 0)",
             },
           },
+          additionalProperties: false,
           required: ["query"],
         },
+        outputSchema: OUTPUT_SCHEMAS.search_symbols,
         annotations: {
           readOnlyHint: true,
           idempotentHint: true,
@@ -489,8 +536,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description: "Output mode: 'summary' for normalized output (default), 'raw' for passthrough.",
             },
           },
+          additionalProperties: false,
           required: ["market"],
         },
+        outputSchema: OUTPUT_SCHEMAS.get_market_metainfo,
         annotations: {
           readOnlyHint: true,
           idempotentHint: true,
@@ -518,8 +567,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description: "Include oscillator and moving average scores breakdown (default: true)",
             },
           },
+          additionalProperties: false,
           required: ["symbols"],
         },
+        outputSchema: OUTPUT_SCHEMAS.get_ta_summary,
         annotations: {
           readOnlyHint: true,
           idempotentHint: true,
@@ -547,8 +598,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               description: "Per-timeframe weights for ranking. Unspecified timeframes default to weight 1. Example: {\"1D\": 3, \"1W\": 2}",
             },
           },
+          additionalProperties: false,
           required: ["symbols"],
         },
+        outputSchema: OUTPUT_SCHEMAS.rank_by_ta,
         annotations: {
           readOnlyHint: true,
           idempotentHint: true,
@@ -565,32 +618,19 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
 
     switch (name) {
-      case "screen_stocks": {
-        const result = await screenTool.screenStocks(args as any);
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
-      }
+      case "screen_stocks":
+        return createToolResult(
+          await screenTool.screenStocks(validateScreenInput(args ?? {}))
+        );
 
-      case "list_fields": {
-        const result = fieldsTool.listFields(args as any);
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
-      }
+      case "list_fields":
+        return createToolResult(
+          fieldsTool.listFields(validateListFieldsInput(args ?? {}))
+        );
 
       case "get_preset": {
-        const preset = presetsTool.getPreset((args as any).preset_name);
+        const { preset_name } = validatePresetInput(args);
+        const preset = presetsTool.getPreset(preset_name);
         if (!preset) {
           return {
             content: [
@@ -602,123 +642,54 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             isError: true,
           };
         }
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(preset, null, 2),
-            },
-          ],
-        };
+        return createToolResult(preset);
       }
 
       case "list_presets": {
+        validateEmptyToolInput(args ?? {});
         const presets = presetsTool.listPresets();
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(presets, null, 2),
-            },
-          ],
-        };
+        return createToolResult(presets, { presets });
       }
 
-      case "screen_forex": {
-        const result = await screenTool.screenForex(args as any);
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
-      }
+      case "screen_forex":
+        return createToolResult(
+          await screenTool.screenForex(validateScreenInput(args ?? {}, false))
+        );
 
-      case "screen_crypto": {
-        const result = await screenTool.screenCrypto(args as any);
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
-      }
+      case "screen_crypto":
+        return createToolResult(
+          await screenTool.screenCrypto(validateScreenInput(args ?? {}, false))
+        );
 
-      case "screen_etf": {
-        const result = await screenTool.screenETF(args as any);
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
-      }
+      case "screen_etf":
+        return createToolResult(
+          await screenTool.screenETF(validateScreenInput(args ?? {}))
+        );
 
-      case "lookup_symbols": {
-        const result = await screenTool.lookupSymbols(args as any);
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
-      }
+      case "lookup_symbols":
+        return createToolResult(
+          await screenTool.lookupSymbols(validateLookupInput(args))
+        );
 
-      case "search_symbols": {
-        const result = await searchTool.searchSymbols(args as any);
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
-      }
+      case "search_symbols":
+        return createToolResult(
+          await searchTool.searchSymbols(validateSearchInput(args))
+        );
 
-      case "get_market_metainfo": {
-        const result = await metainfoTool.getMetainfo(args as any);
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
-      }
+      case "get_market_metainfo":
+        return createToolResult(
+          await metainfoTool.getMetainfo(validateMetainfoInput(args))
+        );
 
-      case "get_ta_summary": {
-        const result = await taTool.getTASummary(args as any);
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
-      }
+      case "get_ta_summary":
+        return createToolResult(
+          await taTool.getTASummary(validateTASummaryInput(args))
+        );
 
-      case "rank_by_ta": {
-        const result = await taTool.rankByTA(args as any);
-        return {
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
-      }
+      case "rank_by_ta":
+        return createToolResult(
+          await taTool.rankByTA(validateRankByTAInput(args))
+        );
 
       default:
         return {

--- a/src/tests/mcp-contracts.test.ts
+++ b/src/tests/mcp-contracts.test.ts
@@ -1,0 +1,117 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+async function withMcpClient<T>(run: (client: Client) => Promise<T>): Promise<T> {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["--import", "tsx/esm", "src/index.ts"],
+    cwd: PROJECT_ROOT,
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "contract-test", version: "1.0.0" });
+  await client.connect(transport);
+  try {
+    return await run(client);
+
+  } finally {
+    await client.close();
+  }
+}
+function textFromResult(result: unknown): string {
+  if (typeof result !== "object" || result === null || !("content" in result)) {
+    throw new Error("MCP result does not contain content");
+  }
+  const content = result.content;
+  if (!Array.isArray(content)) throw new Error("MCP result content is not an array");
+  const first = content[0];
+  if (
+    typeof first !== "object" ||
+    first === null ||
+    !("text" in first) ||
+    typeof first.text !== "string"
+  ) {
+    throw new Error("MCP result does not contain text content");
+  }
+  return first.text;
+}
+
+function recordFromResult(result: unknown): Record<string, unknown> {
+  if (
+    typeof result !== "object" ||
+    result === null ||
+    !("structuredContent" in result) ||
+    typeof result.structuredContent !== "object" ||
+    result.structuredContent === null ||
+    Array.isArray(result.structuredContent)
+  ) {
+    throw new Error("MCP result does not contain structured content");
+  }
+  return result.structuredContent as Record<string, unknown>;
+}
+
+describe("MCP wire contracts", () => {
+  it("publishes output schemas for every public tool", async () => {
+    await withMcpClient(async (client) => {
+      const result = await client.listTools();
+      const expectedTools = [
+        "screen_stocks",
+        "screen_forex",
+        "screen_crypto",
+        "screen_etf",
+        "lookup_symbols",
+        "search_symbols",
+        "get_market_metainfo",
+        "get_ta_summary",
+        "rank_by_ta",
+        "list_fields",
+        "get_preset",
+        "list_presets",
+      ];
+
+      assert.deepEqual(
+        result.tools.map((tool) => tool.name).sort(),
+        expectedTools.sort()
+      );
+      for (const tool of result.tools) {
+        assert.equal(tool.outputSchema?.type, "object", tool.name);
+      }
+    });
+  });
+
+  it("validates malformed filters before touching the upstream API", async () => {
+    await withMcpClient(async (client) => {
+      const result = await client.callTool({
+        name: "screen_stocks",
+        arguments: {
+          filters: [{ field: "close", operator: "above_percent", value: 5 }],
+        },
+      });
+      assert.equal(result.isError, true);
+      const text = textFromResult(result);
+      assert.match(text, /above_percent requires \[field, finite percent\]/);
+    });
+  });
+
+  it("handles omitted optional arguments and preserves list-presets text output", async () => {
+    await withMcpClient(async (client) => {
+      const result = await client.callTool({ name: "list_presets", arguments: {} });
+      assert.equal(result.isError, undefined);
+      const structured = recordFromResult(result);
+      assert.ok(Array.isArray(structured.presets));
+      const text = textFromResult(result);
+      assert.ok(Array.isArray(JSON.parse(text)));
+
+      const fieldsResult = await client.callTool({ name: "list_fields" });
+      assert.equal(fieldsResult.isError, undefined);
+      const fields = recordFromResult(fieldsResult);
+      assert.ok(Array.isArray(fields.fields));
+    });
+  });
+});

--- a/src/tests/screen.test.ts
+++ b/src/tests/screen.test.ts
@@ -254,6 +254,7 @@ describe("ScreenTool - Filter Validation", () => {
                   operator,
                   value: operator === "in_range" || operator === "not_in_range" ? [10, 100]
                     : operator === "above_percent" || operator === "below_percent" ? ["SMA200", 10]
+                    : ["crosses", "crosses_above", "crosses_below", "match"].includes(operator) ? "SMA200"
                     : operator === "has" || operator === "has_none_of" ? ["common"]
                     : 10,
                 },

--- a/src/tests/validation.test.ts
+++ b/src/tests/validation.test.ts
@@ -1,0 +1,141 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  validateEmptyToolInput,
+  validateListFieldsInput,
+  validateLookupInput,
+  validateMetainfoInput,
+  validatePresetInput,
+  validateRankByTAInput,
+  validateScreenInput,
+  validateSearchInput,
+  validateTASummaryInput,
+} from "../api/validation.js";
+import { OUTPUT_SCHEMAS } from "../api/schemas.js";
+
+describe("MCP input validation", () => {
+  it("normalizes an omitted screen filter list and preserves valid options", () => {
+    assert.deepEqual(
+      validateScreenInput({
+        markets: ["america"],
+        sort_order: "asc",
+        limit: 5,
+        columns: ["name", "close"],
+      }),
+      {
+        filters: [],
+        markets: ["america"],
+        sort_order: "asc",
+        limit: 5,
+        columns: ["name", "close"],
+      }
+    );
+  });
+  it("rejects a null filter list instead of treating it as omitted", () => {
+    assert.throws(() => validateScreenInput({ filters: null }), /filters must be an array/);
+  });
+
+  it("rejects malformed operator-specific filter values before transport", () => {
+    assert.throws(
+      () => validateScreenInput({
+        filters: [{ field: "close", operator: "above_percent", value: 5 }],
+      }),
+      /above_percent requires \[field, finite percent\]/
+    );
+    assert.throws(
+      () => validateScreenInput({
+        filters: [{ field: "typespecs", operator: "has", value: "common" }],
+      }),
+      /has requires a non-empty string array/
+    );
+    assert.throws(
+      () => validateScreenInput({
+        filters: [{ field: "dividend_yield_recent", operator: "empty", value: null }],
+      }),
+      /empty does not accept a value/
+    );
+  });
+
+  it("rejects unknown screen properties and invalid limits", () => {
+    assert.throws(() => validateScreenInput({ filters: [], unexpected: true }), /unknown argument 'unexpected'/);
+    assert.throws(() => validateScreenInput({ filters: [], limit: 0 }), /limit must be an integer from 1 to 200/);
+    assert.throws(() => validateScreenInput({ filters: [], sort_order: "sideways" }), /sort_order must be 'asc' or 'desc'/);
+  });
+
+  it("validates lookup and search bounds", () => {
+    assert.deepEqual(validateLookupInput({ symbols: ["NASDAQ:AAPL"] }), { symbols: ["NASDAQ:AAPL"] });
+    assert.throws(() => validateLookupInput({ symbols: [] }), /symbols must contain 1 to 100/);
+    assert.throws(() => validateLookupInput({ symbols: ["NASDAQ:AAPL", 4] }), /symbols must contain/);
+
+    assert.deepEqual(validateSearchInput({ query: "apple", limit: 10, start: 2 }), {
+      query: "apple",
+      limit: 10,
+      start: 2,
+    });
+    assert.throws(() => validateSearchInput({ query: "", limit: 10 }), /query must be a non-empty string/);
+    assert.throws(() => validateSearchInput({ query: "apple", limit: 51 }), /limit must be an integer from 1 to 50/);
+    assert.throws(() => validateSearchInput({ query: "apple", start: -1 }), /start must be a non-negative integer/);
+    assert.throws(() => validateSearchInput({ query: "apple", asset_type: ["stock"] }), /asset_type must be one of/);
+  });
+
+  it("validates metainfo, TA, fields, preset, and empty inputs", () => {
+    assert.deepEqual(validateMetainfoInput({ market: "america", mode: "raw" }), {
+      market: "america",
+      mode: "raw",
+    });
+    assert.throws(() => validateMetainfoInput({ market: "america", mode: "invalid" }), /mode must be 'summary' or 'raw'/);
+
+    assert.deepEqual(validateTASummaryInput({ symbols: ["NASDAQ:AAPL"] }), {
+      symbols: ["NASDAQ:AAPL"],
+    });
+    assert.throws(() => validateTASummaryInput({ symbols: [], timeframes: ["1D"] }), /symbols must contain 1 to 50/);
+    assert.throws(() => validateTASummaryInput({ symbols: ["NASDAQ:AAPL"], timeframes: ["2D"] }), /invalid timeframe '2D'/);
+
+    assert.deepEqual(validateRankByTAInput({ symbols: ["NASDAQ:AAPL"], weights: { "1D": 2 } }), {
+      symbols: ["NASDAQ:AAPL"],
+      weights: { "1D": 2 },
+    });
+    assert.throws(() => validateRankByTAInput({ symbols: ["NASDAQ:AAPL"], weights: { "1D": -1 } }), /weights must contain finite non-negative numbers/);
+
+    assert.deepEqual(validateListFieldsInput({ asset_type: "stock", category: "technical" }), {
+      asset_type: "stock",
+      category: "technical",
+    });
+    assert.throws(() => validateListFieldsInput({ asset_type: "bond" }), /asset_type must be one of/);
+    assert.throws(() => validateListFieldsInput({ asset_type: ["stock"] }), /asset_type must be one of/);
+    assert.throws(() => validateListFieldsInput({ category: ["technical"] }), /category must be one of/);
+
+    assert.deepEqual(validatePresetInput({ preset_name: "quality_stocks" }), { preset_name: "quality_stocks" });
+    assert.throws(() => validatePresetInput({ preset_name: "" }), /preset_name must be a non-empty string/);
+    assert.deepEqual(validateEmptyToolInput({}), {});
+    assert.throws(() => validateEmptyToolInput({ extra: true }), /unknown argument 'extra'/);
+  });
+});
+
+describe("MCP output schemas", () => {
+  it("publishes an object output schema for every public tool", () => {
+    const toolNames = [
+      "screen_stocks",
+      "screen_forex",
+      "screen_crypto",
+      "screen_etf",
+      "lookup_symbols",
+      "search_symbols",
+      "get_market_metainfo",
+      "get_ta_summary",
+      "rank_by_ta",
+      "list_fields",
+      "get_preset",
+      "list_presets",
+    ];
+
+    for (const toolName of toolNames) {
+      assert.equal(OUTPUT_SCHEMAS[toolName as keyof typeof OUTPUT_SCHEMAS].type, "object", toolName);
+    }
+    assert.ok("stocks" in OUTPUT_SCHEMAS.screen_stocks.properties);
+    assert.ok("pairs" in OUTPUT_SCHEMAS.screen_forex.properties);
+    assert.ok("cryptocurrencies" in OUTPUT_SCHEMAS.screen_crypto.properties);
+    assert.ok("etfs" in OUTPUT_SCHEMAS.screen_etf.properties);
+  });
+});

--- a/src/tools/screen.ts
+++ b/src/tools/screen.ts
@@ -6,33 +6,12 @@ import type {
   ScreenStocksInput,
   ScreenerRequest,
   Filter,
-  FilterOperation,
 } from "../api/types.js";
+import { validateScreenFilters } from "../api/validation.js";
 import type { TradingViewClient } from "../api/client.js";
 import type { Cache } from "../utils/cache.js";
 import type { RateLimiter } from "../utils/rateLimit.js";
-
-// Operator mapping from MCP to TradingView API
-const OPERATOR_MAP: Record<string, FilterOperation> = {
-  greater: "greater",
-  less: "less",
-  greater_or_equal: "egreater",
-  less_or_equal: "eless",
-  equal: "equal",
-  not_equal: "nequal",
-  in_range: "in_range",
-  not_in_range: "not_in_range",
-  crosses: "crosses",
-  crosses_above: "crosses_above",
-  crosses_below: "crosses_below",
-  match: "match",
-  above_percent: "above%",
-  below_percent: "below%",
-  has: "has",
-  has_none_of: "has_none_of",
-  empty: "empty",
-  not_empty: "nempty",
-};
+export { validateScreenFilters } from "../api/validation.js";
 
 // Minimal default columns for lean responses
 const DEFAULT_COLUMNS = [
@@ -85,47 +64,6 @@ export const EXTENDED_COLUMNS = [
   "industry",
   "fundamental_currency_code",
 ];
-
-export function validateScreenFilters(
-  filters: ScreenStocksInput["filters"]
-): Filter[] {
-  return filters.map((f, index) => {
-    if (!f || typeof f !== "object" || Array.isArray(f)) {
-      throw new Error(
-        `Invalid filter at index ${index}: expected object with {field, operator, value}, got ${typeof f}`
-      );
-    }
-
-    if (!f.field || !f.operator) {
-      throw new Error(
-        `Invalid filter at index ${index}: missing required properties (field: ${f.field}, operator: ${f.operator}, value: ${f.value})`
-      );
-    }
-    if (typeof f.field !== "string" || typeof f.operator !== "string") {
-      throw new Error(`Invalid filter at index ${index}: field and operator must be non-empty strings`);
-    }
-    const noValueOperators = ["empty", "not_empty"];
-    if (f.value === undefined && !noValueOperators.includes(f.operator)) {
-      throw new Error(
-        `Invalid filter at index ${index}: missing required properties (field: ${f.field}, operator: ${f.operator}, value: ${f.value})`
-      );
-    }
-
-    if (!Object.hasOwn(OPERATOR_MAP, f.operator)) {
-      throw new Error(
-        `Unknown operator: ${f.operator}. Valid operators: ${Object.keys(OPERATOR_MAP).join(", ")}`
-      );
-    }
-    const operation = OPERATOR_MAP[f.operator];
-    if (!operation) {
-      throw new Error(
-        `Unknown operator: ${f.operator}. Valid operators: ${Object.keys(OPERATOR_MAP).join(", ")}`
-      );
-    }
-
-    return { left: f.field, operation, right: f.value };
-  });
-}
 
 export class ScreenTool {
   constructor(


### PR DESCRIPTION
## Summary
- centralize runtime validation for all public MCP inputs and strict operator-specific filter values
- remove untyped `args as any` dispatch casts and publish object output schemas for every tool
- return structured MCP content while preserving the historical `list_presets` text array
- reuse the shared filter validator for strict preset files

Closes #52

## Verification
- `npm test` — 227 passed
- `npm run build`
- MCP stdio contract smoke tests cover tool listing, malformed input rejection, optional arguments, and structured output